### PR TITLE
Engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/rust:1.34.1
+    steps:
+      - checkout
+      - run:
+          name: "Install Dependencies and Build"
+          command: |
+            rustup install nightly
+            rustup default nightly
+            cargo build
+      - run:
+          name: "Run Test Suite"
+          command: |
+            cargo test
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ Usage
 -----
 
 TBD
+
+Testing
+-------
+
+To build and run tests:
+
+    cargo test


### PR DESCRIPTION
Add a CircleCI integration.

Unfortunately, I haven't been able to find a Rust toolchain which can compile `tokio-async-await`. Until the full async/await feature lands in stable this fall we'll need something non-standard.

Nevertheless, reporting the failed state of this build is better than just not knowing what's going on.