### PR TITLE
Re-engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/rust:1.34.1
+    steps:
+      - checkout
+      - run:
+          name: "Install Dependencies and Build"
+          command: |
+            cargo build
+      - run:
+          name: "Run Test Suite"
+          command: |
+            cargo test
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ Usage
 -----
 
 TBD
+
+Testing
+-------
+
+To build and run tests:
+
+    cargo test


### PR DESCRIPTION
Since `master` was force-reset, we now need to set up CircleCI again.

This config is slightly simpler because we don't need `nightly` Rust.